### PR TITLE
OCTO-45 PID issue

### DIFF
--- a/sbin/config.sh
+++ b/sbin/config.sh
@@ -11,7 +11,7 @@ export OCTOHAVEN_PORT="33900"
 ### Octohaven Spark settings
 #################################################
 # Spark full master address to execute Spark jobs on a cluster
-export OCTOHAVEN_SPARK_MASTER_ADDRESS="spark://jony-local.local:7077"
+export OCTOHAVEN_SPARK_MASTER_ADDRESS="spark://jony-local.lan:7077"
 # Spark full UI address (the one for job monitoring)
 export OCTOHAVEN_SPARK_UI_ADDRESS="http://localhost:8080"
 # Root folder as starting point to show .jar files, can have nested folders, this will show file

--- a/test/unittest_scheduler.py
+++ b/test/unittest_scheduler.py
@@ -94,7 +94,7 @@ class SchedulerTestSuite(unittest.TestCase):
         p1 = Popen(cmdList)
         try:
             self.assertEqual(scheduler.updateProcessStatus(p1.pid), -1)
-        except BaseException as e:
+        except Exception as e:
             print "[ERROR] Something bad happened while launching process p1: %s" % e.message
             self.assertEqual(False, True)
         finally:


### PR DESCRIPTION
Fixes PID issue, when after system restart there is a possibility of having a staled job process with pid, that has been assigned to completely different process. Method, in addition to fetching only that pid, also checks that pid belongs to spark-submit. Closes #45.