### PR TITLE
OCTO-48 Update Spark master address

### DIFF
--- a/run_service.py
+++ b/run_service.py
@@ -81,6 +81,8 @@ Options are:
     if not jar_folder or not os.path.exists(jar_folder):
         raise StandardError("Jar folder must be set " + \
             "and be a valid directory, got %s" % str(jar_folder))
+    # resolve "force-spark-master-address"
+    force_spark_addr = True if getOrElse(params, "--force-spark-master-address", None) else False
 
     # global settings necessary to run application
     settings = {
@@ -90,7 +92,8 @@ Options are:
         "JAR_FOLDER": jar_folder,
         "REDIS_HOST": redis_host,
         "REDIS_PORT": redis_port,
-        "REDIS_DB": redis_db
+        "REDIS_DB": redis_db,
+        "FORCE_SPARK_MASTER_ADDRESS": force_spark_addr
     }
 
     # prepare server
@@ -99,6 +102,7 @@ Options are:
 
     print "[INFO] Spark UI address is set to %s" % spark_ui_address
     print "[INFO] Spark Master address is set to %s" % spark_master_address
+    print "[INFO] Force new Spark Master address: %s" % force_spark_addr
     print "[INFO] Jar folder is set to %s" % jar_folder
     print "[INFO] Redis host and port are set to %s:%s" % (redis_host, redis_port)
     print "[INFO] Using Redis db %s" % redis_db

--- a/run_tests.py
+++ b/run_tests.py
@@ -17,7 +17,8 @@ RUN_TESTS = {
     "scheduler": True,
     "subscription": True,
     "timetable": True,
-    "crontab": True
+    "crontab": True,
+    "timetablescheduler": True
 }
 
 def checkTest(key):
@@ -107,6 +108,13 @@ def collectSystemTests(suites):
         suites.addTest(unittest_crontab.loadSuites())
     else:
         print "@skip: 'crontab' tests"
+
+    # timetablescheduler
+    if checkTest("timetablescheduler"):
+        import test.unittest_timetablescheduler as unittest_timetablescheduler
+        suites.addTest(unittest_timetablescheduler.loadSuites())
+    else:
+        print "@skip: 'timetablescheduler' tests"
 
 if __name__ == '__main__':
     args = sys.argv[2:]

--- a/sbin/config.sh
+++ b/sbin/config.sh
@@ -17,6 +17,12 @@ export OCTOHAVEN_SPARK_UI_ADDRESS="http://localhost:8080"
 # Root folder as starting point to show .jar files, can have nested folders, this will show file
 # catalog starting from this folder specified. Please try specifying some more precise than root "/"
 export JAR_FOLDER="/Users/sadikovi/developer/octohaven/test/resources/filelist"
+# Force new Spark master address, recommended to set this option.
+# If variable is set, it will update master address for a staled job with previous address to the
+# valid address specified in configuration file before launching it, e.g. job was saved with
+# address "spark://old.address:7077", address was updated to "spark://new.address:7077", job will
+# be executed with new address, if configuration option is set.
+export FORCE_SPARK_MASTER_ADDRESS="YES"
 
 #################################################
 ### Docker Redis settings
@@ -33,7 +39,8 @@ export REDIS_CONTAINER="octohaven-redis-container"
 ### Redis settings
 #################################################
 # If Docker is used (USE_DOCKER is non-empty) Redis host will be assigned as container host
-# (Docker ip address) automatically, and port will be bound to the REDIS_PORT specified.
+# (container IP address) automatically, and port will be bound to the REDIS_PORT specified. It is
+# recommended not to change these settings, if USE_DOCKER is set.
 # Otherwise, it will use REDIS_HOST and REDIS_PORT to connect to Redis instance running.
 export REDIS_HOST="sandbox"
 # Redis port

--- a/sbin/config.sh
+++ b/sbin/config.sh
@@ -18,10 +18,10 @@ export OCTOHAVEN_SPARK_UI_ADDRESS="http://localhost:8080"
 # catalog starting from this folder specified. Please try specifying some more precise than root "/"
 export JAR_FOLDER="/Users/sadikovi/developer/octohaven/test/resources/filelist"
 # Force new Spark master address, recommended to set this option.
-# If variable is set, it will update master address for a staled job with previous address to the
-# valid address specified in configuration file before launching it, e.g. job was saved with
-# address "spark://old.address:7077", address was updated to "spark://new.address:7077", job will
-# be executed with new address, if configuration option is set.
+# If variable is set (non-empty), it will update master address for a staled job with previous
+# address to the valid address specified in configuration file before launching it, e.g. job was
+# saved with address "spark://old.address:7077", address was updated to "spark://new.address:7077",
+# job will be executed with new address, if configuration option is set.
 export FORCE_SPARK_MASTER_ADDRESS="YES"
 
 #################################################

--- a/sbin/start.sh
+++ b/sbin/start.sh
@@ -101,7 +101,8 @@ RUN_SERVICE_COMMAND="$WHICH_PYTHON $ROOT_DIR/run_service.py \
     --redis-host=$REDIS_HOST \
     --redis-port=$REDIS_PORT \
     --redis-db=$REDIS_DB \
-    --jar-folder=$JAR_FOLDER"
+    --jar-folder=$JAR_FOLDER \
+    --force-spark-master-address=$FORCE_SPARK_MASTER_ADDRESS"
 
 if [ -n "$OPTION_USE_DAEMON" ]; then
     echo "[INFO] Launching service as daemon process..."

--- a/src/job.py
+++ b/src/job.py
@@ -171,6 +171,14 @@ class SparkJob(object):
         return SparkJob(uid, self.name, self.masterurl, self.entrypoint, self.jar, self.options,
             self.jobconf)
 
+    # update Spark master url
+    def updateMasterUrl(self, masterUrl):
+        self.masterurl = JobCheck.validateMasterUrl(masterUrl)
+
+    # return current master url
+    def getMasterUrl(self):
+        return self.masterurl
+
     @classmethod
     def fromDict(cls, obj):
         # validate spark job uid to fetch only SparkJob instances
@@ -231,6 +239,10 @@ class Job(object):
         assertType(newTime, LongType)
         newTime = -1L if newTime < -1L else newTime
         self.finishtime = newTime
+
+    # get current Spark job
+    def getSparkJob(self):
+        return self.sparkjob
 
     def toDict(self):
         return {

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -224,8 +224,8 @@ class Scheduler(Octolog, object):
         self.isRunning = False
         # force new Spark master address. If true, it will update master address for a staled job
         # to the valid address specified in configuration file before launching it, e.g. job was
-        # saved with address "spark://address1:7077", address was updated to "spark://update:7077",
-        # job will be executed with new address, if option is true.
+        # saved with address "spark://old.address:7077", address was updated to
+        # "spark://new.address:7077", job will be executed with new address, if option is true.
         self.forceSparkMasterAddress = settings["FORCE_SPARK_MASTER_ADDRESS"] if \
             "FORCE_SPARK_MASTER_ADDRESS" in settings else False
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -259,6 +259,10 @@ class Scheduler(Octolog, object):
         self.storageManager.saveItem(job, Job)
         self.storageManager.addItemToKeyspace(provider.keyspace(newStatus), job.uid)
 
+    # update only job, assuming that all object properties have been updated
+    def updateJobOnly(self, job):
+        self.storageManager.saveItem(job, Job)
+
     def linkForUid(self, uid):
         return self.storageManager.itemForUid(uid, klass=Link)
 
@@ -335,6 +339,8 @@ class Scheduler(Octolog, object):
                 self.logger().warning("Job master url %s will be updated to new master url %s",
                     sparkJob.getMasterUrl(), self.sparkModule.masterAddress)
                 sparkJob.updateMasterUrl(self.sparkModule.masterAddress)
+                # update job in storage
+                self.updateJobOnly(job)
         # get execute command
         cmd = job.execCommand()
         self.logger().info("Executing command: %s", str(cmd))

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -222,6 +222,12 @@ class Scheduler(Octolog, object):
         self.maxRunningJobs = 1
         # whether timers are running
         self.isRunning = False
+        # force new Spark master address. If true, it will update master address for a staled job
+        # to the valid address specified in configuration file before launching it, e.g. job was
+        # saved with address "spark://address1:7077", address was updated to "spark://update:7077",
+        # job will be executed with new address, if option is true.
+        self.forceSparkMasterAddress = settings["FORCE_SPARK_MASTER_ADDRESS"] if \
+            "FORCE_SPARK_MASTER_ADDRESS" in settings else False
 
     @private
     def hasNext(self):
@@ -322,6 +328,14 @@ class Scheduler(Octolog, object):
     # Also specify stdout and stderr folders for a job
     # Returns process id for a job
     def executeSparkJob(self, job):
+        if self.forceSparkMasterAddress:
+            # check if Spark master address is different from saved job address
+            sparkJob = job.getSparkJob()
+            if sparkJob.getMasterUrl() != self.sparkModule.masterAddress:
+                self.logger().warning("Job master url %s will be updated to new master url %s",
+                    sparkJob.getMasterUrl(), self.sparkModule.masterAddress)
+                sparkJob.updateMasterUrl(self.sparkModule.masterAddress)
+        # get execute command
         cmd = job.execCommand()
         self.logger().info("Executing command: %s", str(cmd))
         # open output and error files in folder specific for that jobid

--- a/test/unittest_job.py
+++ b/test/unittest_job.py
@@ -226,6 +226,22 @@ class SparkJobTestSuite(unittest.TestCase):
         obj["uid"] = None
         self.assertEqual(copyObj, obj)
 
+    def test_updateMasterUrl(self):
+        sparkjob = JobSentinel.sparkJob()
+        self.assertTrue(sparkjob.masterurl is not None)
+        with self.assertRaises(StandardError):
+            sparkjob.updateMasterUrl(None)
+        with self.assertRaises(StandardError):
+            sparkjob.updateMasterUrl("http://localhost:8080")
+        sparkjob.updateMasterUrl("spark://updated:7077")
+        self.assertEqual(sparkjob.masterurl, "spark://updated:7077")
+
+    def test_getMasterUrl(self):
+        sparkjob = JobSentinel.sparkJob()
+        self.assertEqual(sparkjob.getMasterUrl(), sparkjob.masterurl)
+        sparkjob.updateMasterUrl("spark://updated:7077")
+        self.assertEqual(sparkjob.getMasterUrl(), "spark://updated:7077")
+
 class JobTestSuite(unittest.TestCase):
     def setUp(self):
         self.uid = nextJobId()
@@ -351,6 +367,11 @@ class JobTestSuite(unittest.TestCase):
         self.assertEqual(job.starttime, self.submittime)
         job.updateStartTime(currentTimeMillis())
         self.assertTrue(job.starttime >= currentTimeMillis() - 1000L)
+
+    def test_getSparkJob(self):
+        job = Job(self.uid, self.status, self.createtime, self.submittime,
+            self.duration, self.sparkjob)
+        self.assertEqual(job.getSparkJob(), self.sparkjob)
 
 # Load test suites
 def _suites():

--- a/test/unittest_scheduler.py
+++ b/test/unittest_scheduler.py
@@ -35,6 +35,11 @@ class SchedulerTestSuite(unittest.TestCase):
         scheduler = Scheduler(self.settings)
         self.assertEqual(scheduler.poolSize, 5)
         self.assertEqual(scheduler.isRunning, False)
+        self.assertEqual(scheduler.forceSparkMasterAddress, False)
+        # update settings to include "force-master-address" option
+        self.settings["FORCE_SPARK_MASTER_ADDRESS"] = True
+        scheduler = Scheduler(self.settings)
+        self.assertEqual(scheduler.forceSparkMasterAddress, True)
 
     def test_fetchStatus(self):
         job1 = JobSentinel.job()

--- a/test/unittest_timetablescheduler.py
+++ b/test/unittest_timetablescheduler.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import unittest
+from src.redisconnector import RedisConnectionPool, RedisConnector
+from src.timetablescheduler import TimetableScheduler
+from unittest_constants import RedisConst
+
+class TimetableSchedulerTestSuite(unittest.TestCase):
+    def setUp(self):
+        test_pool = RedisConnectionPool({
+            "host": RedisConst.redisHost(),
+            "port": RedisConst.redisPort(),
+            "db": RedisConst.redisTestDb()
+        })
+        self.connector = RedisConnector(test_pool)
+        self.connector.flushdb()
+        self.settings = {
+            "REDIS_HOST": RedisConst.redisHost(),
+            "REDIS_PORT": RedisConst.redisPort(),
+            "REDIS_DB": RedisConst.redisTestDb(),
+            "SPARK_UI_ADDRESS": "http://localhost:8080",
+            "SPARK_UI_RUN_ADDRESS": "http://localhost:4040",
+            "SPARK_MASTER_ADDRESS": "spark://localhost:7077"
+        }
+
+    def tearDown(self):
+        self.connector = None
+
+    def test_init(self):
+        with self.assertRaises(StandardError):
+            tscheduler = TimetableScheduler({})
+        tscheduler = TimetableScheduler(self.settings)
+        self.assertEqual(tscheduler.pool, {})
+
+# Load test suites
+def _suites():
+    return [
+        TimetableSchedulerTestSuite
+    ]
+
+# Load tests
+def loadSuites():
+    # global test suite for this module
+    gsuite = unittest.TestSuite()
+    for suite in _suites():
+        gsuite.addTest(unittest.TestLoader().loadTestsFromTestCase(suite))
+    return gsuite
+
+if __name__ == '__main__':
+    suite = loadSuites()
+    print ""
+    print "### Running tests ###"
+    print "-" * 70
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Forces new Spark master address for jobs that were saved with old Spark master address and have not been run yet. For example, timetable created for job with old master address, launches jobs as clones of that job. `FORCE_SPARK_MASTER_ADDRESS` allows to overwrite address, so job will be executed correctly. Also updates job in storage, thus UI displays correct master address that was used to launch the job. Closes #48.