### PR TITLE
OCTO-46 Scheduler pool fix

### DIFF
--- a/bin/cleanup.sh
+++ b/bin/cleanup.sh
@@ -10,7 +10,7 @@ for f in $(find "$ROOT_DIR" -name "*.pyc" -type f); do
 done
 # delete sass cache
 echo "[INFO] Removing sass-cache files in $ROOT_DIR"
-if [ -d "$ROOT_DIR/.sass-cache" ]; then
+if [[ -d "$ROOT_DIR/.sass-cache" ]]; then
     echo "- Removing directory"
     rm -r "$ROOT_DIR/.sass-cache"
 fi

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -86,3 +86,6 @@ fi
 if [ -n "$INTEGRATION_TESTS_FAILED" ]; then
     exit 1
 fi
+
+# if no fail tests display success message
+echo "All good!"

--- a/test/unittest_scheduler.py
+++ b/test/unittest_scheduler.py
@@ -62,20 +62,20 @@ class SchedulerTestSuite(unittest.TestCase):
         job1 = JobSentinel.job()
         job2 = JobSentinel.job()
         scheduler = Scheduler(self.settings)
-        scheduler.add(job1, job1.priority)
+        scheduler.addLink(job1, job1.priority)
         self.assertEqual(scheduler.pool.qsize(), 1)
-        scheduler.add(job2, job2.priority)
+        scheduler.addLink(job2, job2.priority)
         self.assertEqual(scheduler.pool.qsize(), 2)
         # insert the same job again but with different priority
-        scheduler.add(job2, 1)
+        scheduler.addLink(job2, 1)
         self.assertEqual(scheduler.pool.qsize(), 2)
 
     def test_get(self):
         job1 = JobSentinel.job()
         job2 = JobSentinel.job()
         scheduler = Scheduler(self.settings)
-        scheduler.add(job1, 100)
-        scheduler.add(job2, 101)
+        scheduler.addLink(job1, 100)
+        scheduler.addLink(job2, 101)
         jobids, i = [job1.uid, job2.uid], 0
         while scheduler.hasNext():
             link = scheduler.nextLink()

--- a/test/unittest_scheduler.py
+++ b/test/unittest_scheduler.py
@@ -33,12 +33,14 @@ class SchedulerTestSuite(unittest.TestCase):
         with self.assertRaises(StandardError):
             scheduler = Scheduler({})
         scheduler = Scheduler(self.settings)
-        self.assertEqual(scheduler.poolSize, 5)
+        # check default pool size
+        self.assertEqual(scheduler.poolSize, 3)
         self.assertEqual(scheduler.isRunning, False)
         self.assertEqual(scheduler.forceSparkMasterAddress, False)
         # update settings to include "force-master-address" option
         self.settings["FORCE_SPARK_MASTER_ADDRESS"] = True
-        scheduler = Scheduler(self.settings)
+        scheduler = Scheduler(self.settings, 5)
+        self.assertEqual(scheduler.poolSize, 5)
         self.assertEqual(scheduler.forceSparkMasterAddress, True)
 
     def test_fetchStatus(self):


### PR DESCRIPTION
Fixes scheduler pool bug, when after filling half of the pool, it would refuse to add any new jobs. 
Changes:
- method `::add()` renamed into `addLink()` to reflect its purpose
- scheduler `::fetch()` fix, now we pull `poolSize` jobs regardless how many jobs are currently in the queue.
- default scheduler `poolSize` changed to _3_ from _5_
- small overall updates

Closes #46.