### PR TITLE
OCTO-71 Add script to update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ automate it as much as I can later.
 # 1. Launch docker container
 $ make docker-start
 
-# 2. Change version in 'version.py', 'package.json', 'bower.json'
+# 2. Update version in 'version.py', 'package.json', 'bower.json'
+$ bin/update-version --version=x.y.z
 
 # 3. Change logging and debugging mode in 'log.conf', 'internal.py', if necessary
 
@@ -179,6 +180,8 @@ $ git push
 
 # 8. Pull changes, and turn dev mode on:
 # update next version in 'version.py', 'package.json', 'bower.json'
+$ bin/update-version --version=x.y.z
+
 # update logging and debugging in 'log.conf', 'internal.py' if applicable
 $ git pull
 $ git commit -m "set up next version dev mode"

--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -1,0 +1,1 @@
+bin/python setup.py update_version $@


### PR DESCRIPTION
Adds script to update version:
```
bin/update-version --version=x.y.z
```
where `x.y.z` is desired version.

Also updated documentation part on release process to include this script.